### PR TITLE
Add Conditional Compilation & Linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ set_property(CACHE OTTO_BOARD PROPERTY STRINGS ${OTTO_BOARDS})
 if (OTTO_USE_LIBCXX)
   message("Using libc++ instead of libstdc++")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lc++fs")
+  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lc++fs"
+    $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<AND:$<CXX_COMPILER_ID:Clang>,$<AND:$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,7>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9>>>>:-lc++fs>
+    )
 endif()
 
 set(OTTO_EXTERNAL_DIR ${OTTO_SOURCE_DIR}/external/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,6 @@ set_property(CACHE OTTO_BOARD PROPERTY STRINGS ${OTTO_BOARDS})
 if (OTTO_USE_LIBCXX)
   message("Using libc++ instead of libstdc++")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lc++fs"
-    $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<AND:$<CXX_COMPILER_ID:Clang>,$<AND:$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,7>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9>>>>:-lc++fs>
-    )
 endif()
 
 set(OTTO_EXTERNAL_DIR ${OTTO_SOURCE_DIR}/external/)

--- a/boards/parts/audio/rtaudio/include/board/audio_driver.hpp
+++ b/boards/parts/audio/rtaudio/include/board/audio_driver.hpp
@@ -17,23 +17,6 @@
 #include <alsa/mixer.h>
 #endif
 
-#ifndef __LINUX_ALSA__
-/**
- * It seems from what I can tell the snd_mixer_t is an Alsa
- * construct that doesn't exist on macOS. Eventually this should
- * be removed to support macOS' CoreAudio (I think), but this
- * unblocks basic compilation.
- *
- */
-struct _snd_mixer;
-struct _snd_mixer_elem;
-struct _snd_mixer_selem_id;
-typedef struct _snd_mixer snd_mixer_t;
-typedef struct _snd_mixer_elem snd_mixer_elem_t;
-typedef struct _snd_mixer_selem_id snd_mixer_selem_id_t;
-
-#endif
-
 #include "services/audio_manager.hpp"
 
 namespace otto::services {

--- a/boards/parts/audio/rtaudio/include/board/audio_driver.hpp
+++ b/boards/parts/audio/rtaudio/include/board/audio_driver.hpp
@@ -17,6 +17,23 @@
 #include <alsa/mixer.h>
 #endif
 
+#ifndef __LINUX_ALSA__
+/**
+ * It seems from what I can tell the snd_mixer_t is an Alsa
+ * construct that doesn't exist on macOS. Eventually this should
+ * be removed to support macOS' CoreAudio (I think), but this
+ * unblocks basic compilation.
+ *
+ */
+struct _snd_mixer;
+struct _snd_mixer_elem;
+struct _snd_mixer_selem_id;
+typedef struct _snd_mixer snd_mixer_t;
+typedef struct _snd_mixer_elem snd_mixer_elem_t;
+typedef struct _snd_mixer_selem_id snd_mixer_selem_id_t;
+
+#endif
+
 #include "services/audio_manager.hpp"
 
 namespace otto::services {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,9 @@ otto_add_definitions(otto_exec)
 if (NOT OTTO_USE_LIBCXX)
   target_link_libraries(otto_src PUBLIC atomic)
 else() 
-  target_link_libraries(otto_src PUBLIC c++fs)
+  target_link_libraries(otto_src PUBLIC
+    $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<AND:$<CXX_COMPILER_ID:Clang>,$<AND:$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,7>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9>>>>:-lc++fs>
+    )
 endif()
 
 target_link_libraries(otto_src PUBLIC external)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,10 +23,6 @@ otto_add_definitions(otto_exec)
 
 if (NOT OTTO_USE_LIBCXX)
   target_link_libraries(otto_src PUBLIC atomic)
-else() 
-  target_link_libraries(otto_src PUBLIC
-    $<$<AND:$<NOT:$<PLATFORM_ID:Windows>>,$<AND:$<CXX_COMPILER_ID:Clang>,$<AND:$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,7>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9>>>>:-lc++fs>
-    )
 endif()
 
 target_link_libraries(otto_src PUBLIC external)

--- a/src/services/log_manager.cpp
+++ b/src/services/log_manager.cpp
@@ -1,4 +1,5 @@
 #include "log_manager.hpp"
+
 #include "services/application.hpp"
 
 #define LOGURU_IMPLEMENTATION 1
@@ -31,8 +32,7 @@ namespace otto::services {
     loguru::add_file(logFilePath, loguru::Append, loguru::Verbosity_MAX);
 
     loguru::set_fatal_handler([](const loguru::Message& message) {
-      throw Application::exception(Application::ErrorCode::none,
-                                   std::string(message.prefix) + message.message);
+      throw Application::exception(Application::ErrorCode::none, std::string(message.prefix) + message.message);
     });
 
     LOGI("LOGGING NOW");
@@ -41,7 +41,11 @@ namespace otto::services {
 
   void LogManager::set_thread_name(const std::string& name)
   {
-		pthread_setname_np(pthread_self(), name.c_str());
+#if defined(__APPLE__)
+    pthread_setname_np(name.c_str());
+#else
+    pthread_setname_np(pthread_self(), name.c_str());
+#endif
     loguru::set_thread_name(name.c_str());
   }
 } // namespace otto::services


### PR DESCRIPTION
Hello! I found out about this project this morning and went to go build it on my macOS machine and encountered a few build errors preventing me from completing compilation. 

I did some digging and found that LLVM made `filesystem` part of the standard c++ lib starting at version 9 and above (https://releases.llvm.org/9.0.0/projects/libcxx/docs/UsingLibcxx.html#using-filesystem) so I looked through some other project and found people solving this problem in a similar way (like [here](https://github.com/rubenvb/skui/blob/0fa353546fe4aa59b4c68d7cffd172d31d7db7b1/core/CMakeLists.txt#L80))

I'm certainly no C++ or CMake expert, but this did allow me (in conjunction with the other changes listed) complete the compilation process.

The changes in `audio_driver.cpp` seem related to macOS not using ALSA, and from what I can tell structs like `snd_mixer_t` are all set up from within that library, so I forward declared them wrapped in the `__APPLE__` flag. 

Finally, the changes to `log_manager.cpp` were in a similar vein, the function that was being called just simply doesn't exist in the `pthreads.h` for macOS so I took a similar approach. 

The code compiles, the tests pass, but running the `otto` binary crashes with the following stack
<details>
<summary>stack trace</summary>
<pre>
➜  OTTO git:(bsm/get-macos-compiling-again) build/bin/otto
date       time         ( uptime  ) [ thread name/id ]                   file:line     v|
2020-05-29 11:22:45.480 (   0.000s) [main thread     ]             loguru.hpp:1871     0| arguments: build/bin/otto
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]             loguru.hpp:1874     0| Current dir: /Users/brianmichel/Development/OTTO
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]             loguru.hpp:1876     0| stderr verbosity: 0
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]             loguru.hpp:1877     0| -----------------------------------
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]             loguru.hpp:2031     0| Logging to 'data/log.txt', mode: 'a', verbosity: 9
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]        log_manager.cpp:38       0| LOGGING NOW
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]     preset_manager.cpp:169      0| { void otto::services::DefaultPresetManager::load_preset_files()
2020-05-29 11:22:45.481 (   0.000s) [main thread     ]     preset_manager.cpp:179      0| .   { Loading preset file "data/presets/OTTO.FM/80s EP.json"
2020-05-29 11:22:45.481 (   0.001s) [main thread     ]     preset_manager.cpp:179      0| .   } 0.000 s: Loading preset file "data/presets/OTTO.FM/80s EP.json"
2020-05-29 11:22:45.481 (   0.001s) [main thread     ]     preset_manager.cpp:179      0| .   { Loading preset file "data/presets/OTTO.FM/Braaambr.json"
2020-05-29 11:22:45.481 (   0.001s) [main thread     ]     preset_manager.cpp:179      0| .   } 0.000 s: Loading preset file "data/presets/OTTO.FM/Braaambr.json"
2020-05-29 11:22:45.481 (   0.001s) [main thread     ]     preset_manager.cpp:179      0| .   { Loading preset file "data/presets/Potion/Preset1.json"
2020-05-29 11:22:45.481 (   0.001s) [main thread     ]     preset_manager.cpp:179      0| .   } 0.000 s: Loading preset file "data/presets/Potion/Preset1.json"
2020-05-29 11:22:45.482 (   0.001s) [main thread     ]     preset_manager.cpp:169      0| } 0.001 s: void otto::services::DefaultPresetManager::load_preset_files()

RtApiCore::probeDeviceOpen: the device (0) does not support the requested channel count.

2020-05-29 11:22:45.542 (   0.062s) [main thread     ]         controller.cpp:58       0| Midi input ports:
2020-05-29 11:22:45.542 (   0.062s) [main thread     ]         controller.cpp:136    ERR| Couldn't set up sysex controller. Continuing with dummy. ERR: No input midi port specified. Use --sysex-ctl-in-device=X to select one of the listed ports
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
2020-05-29 11:22:45.543 (   0.062s) [main thread     ]      state_manager.cpp:56     ERR| Exception while loading state for UI: [json.exception.type_error.302] type must be string, but is null

Loguru caught a signal: SIGABRT
2020-05-29 11:22:45.543 (   0.062s) [main thread     ]      state_manager.cpp:56     ERR| Exception while loading state for Engines: [json.exception.type_error.304] cannot use at() with null
Stack trace:
8       0x7fff6dfafb8b thread_start + 15
7       0x7fff6dfb4109 _pthread_start + 148
6       0x7fff6b0dd829 std::terminate() + 41
5       0x7fff6b0dd887 std::__terminate(void (*)()) + 8
4       0x7fff6cc0a5b1 _objc_terminate() + 104
3       0x7fff6b0cf8a7 demangling_terminate_handler() + 238
2       0x7fff6b0de458 abort_message + 231
1       0x7fff6de7e808 abort + 120
0          0x100000400 4   ???                                 0x0000000100000400 0x0 + 4294968320
2020-05-29 11:22:45.543 (   0.062s) [          A2898E]                       :0     FATL| Signal: SIGABRT
Exception caught and ignored by Loguru signal handler.
2020-05-29 11:22:45.543 (   0.062s) [main thread     ]       audio_driver.cpp:121      0| Avaliable RtAudio devices:
2020-05-29 11:22:45.544 (   0.064s) [main thread     ]       audio_driver.cpp:125      0| 0: 'Apple Inc.: MacBook Pro Microphone'. 1 in channels, 0 out channels, 0 duplex channels
</pre>
</details>

I wanted to make this PR even with the crashing as perhaps it could solve some issues for other folks, or the devs can advise me here on what they would like. I'm also a patron of this project so I'm pumped to see it on my local machine!

Let me know what you think!