### PR TITLE
Update Travis To Clang 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-10
+            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
             - ubuntu-toolchain-r-test
           packages:
             - clang-10
@@ -35,7 +35,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-10
+            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
             - ubuntu-toolchain-r-test
           packages:
             - clang-10
@@ -83,7 +83,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-10
+            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
             - ubuntu-toolchain-r-test
           packages:
             - clang-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
             - ubuntu-toolchain-r-test
           packages:
             - clang-10
@@ -36,6 +37,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
             - ubuntu-toolchain-r-test
           packages:
             - clang-10
@@ -84,6 +86,7 @@ matrix:
         apt:
           sources:
             - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
             - ubuntu-toolchain-r-test
           packages:
             - clang-10

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ install:
     LLVM_INSTALL=${DEPS_DIR}/llvm/install
     # if in linux and compiler clang and llvm not installed
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "$USE_LIBCXX" == "1" && ! -d $LLVM_INSTALL ]]; then
-    [[ "${CXX}" == "clang++-10.0" ]] && LLVM_VERSION="10.0.0";
+    [[ "${CXX}" == "clang++-10" ]] && LLVM_VERSION="10.0.0";
     LLVM_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
     LIBCXX_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
     LIBCXXABI_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,67 +13,67 @@ cache:
 
 matrix:
   include:
-
-    - name: "Linux, Clang 8, Debug, libc++"
+    - name: "Linux, Clang 10, Debug, libc++"
       os: linux
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-8
+            - llvm-toolchain-xenial-10
             - ubuntu-toolchain-r-test
           packages:
-            - clang-8
+            - clang-10
             - gdb-minimal
             - libasound-dev
       env:
-        - CC=clang-8 CXX=clang++-8
+        - CC=clang-10 CXX=clang++-10
         - BUILD_TYPE=Debug
         - USE_LIBCXX=1
         - DEPLOY_DOCS=OFF
 
-    - name: "Linux, Clang 8, Release, libstdc++"
+    - name: "Linux, Clang 10, Release, libstdc++"
       os: linux
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-8
+            - llvm-toolchain-xenial-10
             - ubuntu-toolchain-r-test
           packages:
-            - clang-8
+            - clang-10
             - libstdc++-9-dev
             - gdb-minimal
             - libasound-dev
       env:
-        - CC=clang-8 CXX=clang++-8
+        - CC=clang-10 CXX=clang++-10
         - BUILD_TYPE=Release
         - USE_LIBCXX=0
         - DEPLOY_DOCS=OFF
-    - name: "Linux, GCC, Debug"	
-      os: linux	
-      addons:	
-        apt:	
-          sources:	
-            - ubuntu-toolchain-r-test	
-          packages:	
-            - g++-9	
-            - gdb-minimal	
-            - libasound-dev	
-      env:	
-        - CC=gcc-9 CXX=g++-9	
-        - BUILD_TYPE=Debug	
-        - USE_LIBCXX=0	
-        - DEPLOY_DOCS=OFF	
-#    - name: "OSX, Clang, Debug, libc++"
-#      os: osx
-#      osx_image: xcode9.1
-#      env:
-#        - CC=clang CXX=clang++
-#        - MATRIX_EVAL="brew update; brew install gdb llvm"
-#        - LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
-#        - PATH="/usr/local/opt/llvm/bin:$PATH"
-#        - CXXFLAGS="-I/usr/local/opt/llvm/include -I/usr/local/opt/llvm/include/c++/v1/"
-#        - USE_LIBCXX=1
-#        - DEPLOY_DOCS=OFF
+
+    - name: "Linux, GCC, Debug"
+      os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+            - gdb-minimal
+            - libasound-dev
+      env:
+        - CC=gcc-9 CXX=g++-9
+        - BUILD_TYPE=Debug
+        - USE_LIBCXX=0
+        - DEPLOY_DOCS=OFF
+    #    - name: "OSX, Clang, Debug, libc++"
+    #      os: osx
+    #      osx_image: xcode9.1
+    #      env:
+    #        - CC=clang CXX=clang++
+    #        - MATRIX_EVAL="brew update; brew install gdb llvm"
+    #        - LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+    #        - PATH="/usr/local/opt/llvm/bin:$PATH"
+    #        - CXXFLAGS="-I/usr/local/opt/llvm/include -I/usr/local/opt/llvm/include/c++/v1/"
+    #        - USE_LIBCXX=1
+    #        - DEPLOY_DOCS=OFF
 
     - name: "Deploy Docs"
       os: linux
@@ -83,15 +83,15 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-xenial-8
+            - llvm-toolchain-xenial-10
             - ubuntu-toolchain-r-test
           packages:
-            - clang-8
-            - libclang-8-dev
+            - clang-10
+            - libclang-10-dev
             - libasound-dev
             - libtinfo-dev
       env:
-        - CC=clang-8 CXX=clang++-8
+        - CC=clang-10 CXX=clang++-10
         - BUILD_TYPE=Debug
         - USE_LIBCXX=1
         - DEPLOY_DOCS=ON
@@ -141,12 +141,10 @@ install:
     LLVM_INSTALL=${DEPS_DIR}/llvm/install
     # if in linux and compiler clang and llvm not installed
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "$USE_LIBCXX" == "1" && ! -d $LLVM_INSTALL ]]; then
-    [[ "${CXX}" == "clang++-6.0" ]] && LLVM_VERSION="6.0.0";
-    [[ "${CXX}" == "clang++-7.0" ]] && LLVM_VERSION="7.0.0";
-    [[ "${CXX}" == "clang++-8" ]] && LLVM_VERSION="8.0.0";
-    LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
-    LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
-    LIBCXXABI_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"
+    [[ "${CXX}" == "clang++-10.0" ]] && LLVM_VERSION="10.0.0";
+    LLVM_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
+    LIBCXX_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
+    LIBCXXABI_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"
     mkdir -p llvm llvm/build llvm/projects/libcxx llvm/projects/libcxxabi
     travis_retry wget -O - ${LLVM_URL} | tar --strip-components=1 -xJ -C llvm
     travis_retry wget -O - ${LIBCXX_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ set_property(CACHE OTTO_BOARD PROPERTY STRINGS ${OTTO_BOARDS})
 if (OTTO_USE_LIBCXX)
   message("Using libc++ instead of libstdc++")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lc++fs")
 endif()
 
 set(OTTO_EXTERNAL_DIR ${OTTO_SOURCE_DIR}/external/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,6 @@ otto_add_definitions(otto_exec)
 
 if (NOT OTTO_USE_LIBCXX)
   target_link_libraries(otto_src PUBLIC atomic)
-else() 
-  target_link_libraries(otto_src PUBLIC c++fs)
 endif()
 
 target_link_libraries(otto_src PUBLIC external)


### PR DESCRIPTION
We're currently supporting on Clang 10+ for building this project, so we
should clean up our CI jobs to make sure they are using Clang 10 to
catch relevant errors and to match local build environments.

Additionally, it seems like LLVM recently moved all new releases to
being published in Github so we have to change our install scripts to
point to them to download the Clang 10 sources. 

If you check out the [Clang 10 page](https://releases.llvm.org/download.html#10.0.0) on LLVM.org you will see that these redirect to Github so I figured it could be nice to clean up the versions on the install scripts as well as rewrite the URLs to point to Github since we're not supporting a backwards compatible build matrix.

I was unsure if I should also be looking to update `libstdc++` in lockstep with updating Clang, but from my reading it sounds like that is not necessarily the case, but please advise me of what this project usually does. 