### PR TITLE
Upgrade Travis To Newer Ubuntu Distribution & GCC 10 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
           sources:
             - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
               key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-10
             - gdb-minimal
@@ -38,7 +38,7 @@ matrix:
           sources:
             - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
               key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-10
             - libstdc++-9-dev
@@ -55,7 +55,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-9
             - gdb-minimal
@@ -87,7 +87,7 @@ matrix:
           sources:
             - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
               key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-10
             - libclang-10-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ matrix:
 
   allow_failures:
     - name: "Deploy Docs"
+    - name: "Linux, Clang 10, Release, libstdc++ (GCC 10)"
     - os: osx
 
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-dist: focal
+dist: bionic
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-dist: xenial
+dist: focal
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+            - sourceline: "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
               key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
             - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
@@ -31,17 +31,17 @@ matrix:
         - USE_LIBCXX=1
         - DEPLOY_DOCS=OFF
 
-    - name: "Linux, Clang 10, Release, libstdc++"
+    - name: "Linux, Clang 10, Release, libstdc++ (GCC 10)"
       os: linux
       addons:
         apt:
           sources:
-            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+            - sourceline: "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
               key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
             - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-10
-            - libstdc++-9-dev
+            - libstdc++-10-dev
             - gdb-minimal
             - libasound-dev
       env:
@@ -50,18 +50,18 @@ matrix:
         - USE_LIBCXX=0
         - DEPLOY_DOCS=OFF
 
-    - name: "Linux, GCC, Debug"
+    - name: "Linux, GCC 10, Debug"
       os: linux
       addons:
         apt:
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
-            - g++-9
+            - g++-10
             - gdb-minimal
             - libasound-dev
       env:
-        - CC=gcc-9 CXX=g++-9
+        - CC=gcc-10 CXX=g++-10
         - BUILD_TYPE=Debug
         - USE_LIBCXX=0
         - DEPLOY_DOCS=OFF
@@ -85,7 +85,7 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+            - sourceline: "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
               key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
             - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:


### PR DESCRIPTION
Focal Fossa (Ubuntu 20.04) is the latest LTS that was released recently
and will be supported through April 2025. It also seems that Travis is
supporting this, but haven't updated their docs accordingly. This will
bring forward our CI environment to easily give access to new mainline
packages for gcc-10 and more.

I was digging through some logs and found [this](https://github.com/travis-ci/docs-travis-ci-com/pulls?q=is%3Apr+is%3Aopen+focal) which seems to show their docs about to be updated back in February. Additionally, it seems that the Internet Archive also has PRs running for Focal Fossa as well https://github.com/internetarchive/openlibrary/pull/3407